### PR TITLE
建立使用者設定頁 & 泛用型文字輸入框 & 通用按鈕顯示樣式

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -13,4 +13,29 @@ export default {}
 
 <style lang="scss">
 @import url('https://fonts.googleapis.com/css?family=Noto+Sans+TC&display=swap');
+
+// 通用按鈕顏色樣式
+.btn-control {
+  background-color: #FF6600;
+  border: none;
+  color: #FFFFFF;
+
+  &:hover {
+    background-color: #b14700;
+  }
+
+  &[disabled] {
+    opacity: 0.4;
+  }
+}
+.btn-control-outline {
+  background-color: transparent;
+  border: 1px solid #FF6600;
+  color: #FF6600;
+
+  &:hover {
+    background-color: #FF6600;
+    color: #FFFFFF
+  }
+}
 </style>

--- a/src/apis/users.js
+++ b/src/apis/users.js
@@ -1,0 +1,10 @@
+import { apiHelper } from '@/utils/helpers'
+
+export default {
+  getUserData ({ userId }) {
+    return apiHelper.get(`/users/${userId}`)
+  },
+  updateUserSetting ({ userId, formData }) {
+    return apiHelper.put(`/users/${userId}/account`, formData)
+  }
+}

--- a/src/components/FollowControlButton.vue
+++ b/src/components/FollowControlButton.vue
@@ -10,7 +10,7 @@
 <template>
   <button
     class="btn-follow"
-    :class="{'followed': user.followed}"
+    :class="{'btn-control': user.followed, 'btn-control-outline': !user.followed}"
     :disabled="isProcessing"
     @click="toggleFollow(user.followed, user.id)"
   >
@@ -98,33 +98,11 @@ export default {
 
 <style lang="scss" scoped>
 .btn-follow {
-  background-color: transparent;
-  border: 1px solid #FF6600;
   border-radius: 100px;
-  color: #FF6600;
   height: inherit;
   font-size: 15px;
   line-height: 15px;
   padding-left: 15px;
   padding-right: 15px;
-
-  &:hover {
-    background-color: #FF6600;
-    color: #FFFFFF
-  }
-
-  &.followed {
-    background-color: #FF6600;
-    border: none;
-    color: #FFFFFF;
-
-    &:hover {
-      background-color: #b14700;
-    }
-  }
-
-  &[disabled] {
-    opacity: 0.4;
-  }
 }
 </style>

--- a/src/components/GeneralInput.vue
+++ b/src/components/GeneralInput.vue
@@ -1,0 +1,234 @@
+<!--
+名稱：泛用型文字輸入框
+用法：請參照Props區域，在使用時，傳入必要的設定
+功能：
+  1. 顯示初始文字
+  2. 輸入內容長度限制
+  3. 即時顯示輸入內容上限顯示
+  4. 顯示錯誤提示訊息
+  5. 有預設顯示、focus/active狀態顯示和錯誤狀態顯示
+  6. 可設定輸入內容是否對頭尾空白進行去除
+-->
+
+<template>
+  <section class="input-group">
+    <label class="input-label">{{ label }}</label>
+    <span class="input-container">
+      {{ prefix }}
+      <input
+        :value="value"
+        :class="{'invalid': !isValid}"
+        :type="inputType"
+        :minlength="minlength"
+        :maxlength="maxlength"
+        :name="name"
+        :required="required"
+        @input.stop.prevent="value = $event.target.value"
+        @change.stop.prevent="inputChange($event.target.value)"
+      >
+      <div class="input-status-bar" />
+    </span>
+    <div class="input-status-info">
+      <div
+        class="text"
+        :title="errorMessage"
+      >
+        {{ errorMessage }}
+      </div>
+      <div
+        v-show="showLimit && (maxlength > 0)"
+        class="limit"
+      >
+        {{ limitText }}
+      </div>
+    </div>
+  </section>
+</template>
+
+<script>
+export default {
+  props: {
+    // 輸入框是否有前綴
+    prefix: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    // 輸入框標籤文字
+    label: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    // 輸入框type屬性
+    inputType: {
+      type: String,
+      required: true,
+      default: 'text'
+    },
+    // 輸入框文字最短設定
+    minlength: {
+      type: Number,
+      required: false,
+      default: -1
+    },
+    // 輸入框文字最長設定
+    maxlength: {
+      type: Number,
+      required: false,
+      default: -1
+    },
+    // 輸入框name屬性
+    name: {
+      type: String,
+      required: true,
+      default: ''
+    },
+    // 輸入框required屬性
+    required: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    // 輸入框起始值
+    initialValue: {
+      type: [String, Number],
+      required: false,
+      default: ''
+    },
+    // 輸入框錯誤提示訊息
+    errorMessage: {
+      type: String,
+      required: false,
+      default: ''
+    },
+    // 輸入框輸入內容上限顯示
+    showLimit: {
+      type: Boolean,
+      required: false,
+      default: false
+    },
+    // 輸入框文字內容是否去除頭尾空白
+    doTrim: {
+      type: Boolean,
+      required: false,
+      default: true
+    }
+  },
+  data () {
+    return {
+      value: '',
+      isValid: true
+    }
+  },
+  computed: {
+    limitText () {
+      const validType = ['text', 'password']
+
+      if (validType.includes(this.inputType) && this.maxlength > 0) {
+        return `${this.value.length}/${this.maxlength}`
+      }
+
+      return ''
+    }
+  },
+  watch: {
+    initialValue (newValue) {
+      this.value = newValue
+    },
+    errorMessage (newValue) {
+      this.isValid = (newValue === '')
+    }
+  },
+  updated () {
+    console.log('updated')
+  },
+  created () {
+    this.value = this.initialValue
+  },
+  methods: {
+    inputChange (value) {
+      if (typeof value === 'string' && this.doTrim === true) {
+        this.value = value.trim()
+      }
+
+      // 通知上層輸入框的數值改變
+      this.$emit('input-change', this.value)
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+section.input-group {
+  display: flex;
+  flex-direction: column;
+  flex-wrap: nowrap;
+  height: 84px; // input + input-status-bar + input間的距離
+
+  .input-label {
+    color: #657786;
+    font-size: 15px;
+    left: 10px;
+    line-height: 15px;
+    position: absolute;
+    top: 5px;
+  }
+  .input-container {
+    background-color: #F5F8FA;
+    border-radius: 4px 4px 0px 0px;
+    font-size: 19px;
+    font-weight: 500;
+    line-height: 29px;
+    padding-left: 10px;
+    word-spacing: -.25rem;
+
+    .input-status-bar {
+      background-color: #657786;
+      border-radius: 0px 0px 4px 4px;
+      height: 2px;
+      margin-left: -10px;
+    }
+  }
+  .input-status-info {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: nowrap;
+    font-size: 15px;
+    font-weight: 500;
+    justify-content: space-between;
+    line-height: 15px;
+    margin-top: 5px;
+
+    .text {
+      color: #FC5A5A;
+      flex-shrink: 1;
+      min-width: 0;
+      overflow-x: clip;
+      overflow-y: visible;
+      text-overflow: ellipsis;
+    }
+    .limit {
+      color: #657786;
+    }
+  }
+
+  input {
+    background-color: inherit;
+    border: none;
+    padding-bottom: 4px;
+    padding-left: 0px;
+    padding-top: 20px;
+  }
+  input:focus {
+    border: none;
+    outline: none;
+  }
+  input:focus ~ .input-status-bar {
+    background-color: #50B5FF;
+  }
+  input.invalid ~ .input-status-bar {
+    background-color: #FC5A5A;
+  }
+}
+</style>

--- a/src/components/SiteNav.vue
+++ b/src/components/SiteNav.vue
@@ -1,0 +1,10 @@
+<template>
+  <section class="site-nav" />
+</template>
+
+<style lang="scss" scoped>
+section.site-nav {
+  border-right: 1px solid #E6ECF0;
+  width: 378px;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -48,7 +48,7 @@ const routes = [
   {
     path: '/setting',
     name: 'user-setting',
-    component: BlankPage
+    component: () => import('@/views/UserSetting')
   },
   // 首頁
   {

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -6,3 +6,132 @@ export const emptyNameMethod = {
     }
   }
 }
+
+// 檢查資料型態
+function typeCheck ({ input, typeRef }) {
+  const result = {
+    status: true,
+    message: ''
+  }
+
+  if (typeof input !== typeof typeRef) {
+    result.status = false
+    result.message = '資料型態錯誤'
+  }
+
+  return result
+}
+
+// 檢查輸入字串的長度
+function lengthCheck ({ input, min = -1, max = -1 }) {
+  const result = {
+    status: true,
+    message: ''
+  }
+
+  if (min !== -1) {
+    if (input.length < min) {
+      result.status = false
+      result.message = '字數過短'
+      return result
+    }
+  }
+
+  if (max !== -1) {
+    if (input.length > max) {
+      result.status = false
+      result.message = '字數超出上限'
+      return result
+    }
+  }
+
+  return result
+}
+
+// 用正則表達式檢查
+function regexCheck ({ input, regex }) {
+  const result = {
+    status: true,
+    message: ''
+  }
+
+  const re = new RegExp(regex)
+  result.status = re.test(input)
+
+  if (result.status === false) {
+    result.message = '輸入格式錯誤'
+  }
+
+  return result
+}
+
+// 表單輸入驗證方法
+export const inputValidationMethod = {
+  methods: {
+    // 帳號規則：1-20字英數
+    checkAccount (account) {
+      let result
+
+      result = typeCheck({ input: account, typeRef: '' })
+      if (result.status === false) {
+        return result
+      }
+
+      result = lengthCheck({ input: account, min: 1, max: 20 })
+      if (result.status === false) {
+        return result
+      }
+
+      result = regexCheck({ input: account, regex: /^[a-zA-Z0-9]{1,20}$/ })
+
+      return result
+    },
+    // 名稱規則：不超過50字（頭尾去白）
+    checkName (name) {
+      let result
+
+      result = typeCheck({ input: name, typeRef: '' })
+      if (result.status === false) {
+        return result
+      }
+
+      result = lengthCheck({ input: name, max: 50 })
+      if (result.status === false) {
+        return result
+      }
+
+      return result
+    },
+    checkEmail (email) {
+      let result
+
+      result = typeCheck({ input: email, typeRef: '' })
+      if (result.status === false) {
+        return result
+      }
+
+      // Email的正則表示：https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/email#basic_validation
+      result = regexCheck({ input: email, regex: /^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/ })
+
+      return result
+    },
+    // 密碼規則：5-20字英數
+    checkPassword (password) {
+      let result
+
+      result = typeCheck({ input: password, typeRef: '' })
+      if (result.status === false) {
+        return result
+      }
+
+      result = lengthCheck({ input: password, min: 5, max: 20 })
+      if (result.status === false) {
+        return result
+      }
+
+      result = regexCheck({ input: password, regex: /^[a-zA-Z0-9]{5,20}$/ })
+
+      return result
+    }
+  }
+}

--- a/src/views/UserSetting.vue
+++ b/src/views/UserSetting.vue
@@ -1,0 +1,270 @@
+<template>
+  <div class="page-container">
+    <SiteNav />
+    <section
+      v-show="!isLoading"
+      class="setting-container"
+    >
+      <div class="page-header">
+        帳戶設定
+      </div>
+      <form
+        class="setting-form"
+        @submit.stop.prevent="handleSubmit"
+      >
+        <GeneralInput
+          v-for="key in inputKeys"
+          :key="key"
+          v-bind="config[key]"
+          :initial-value="data[key]"
+          :name="key"
+          :error-message="error[key]"
+          @input-change="data[key] = $event"
+        />
+        <button
+          type="submit"
+          class="btn-submit btn-control"
+          :disabled="isProcessing"
+        >
+          儲存
+        </button>
+      </form>
+    </section>
+  </div>
+</template>
+
+<script>
+import SiteNav from '@/components/SiteNav.vue'
+import GeneralInput from '@/components/GeneralInput.vue'
+import usersAPI from '@/apis/users'
+import { inputValidationMethod } from '@/utils/mixins'
+import { Toast } from '@/utils/helpers'
+
+const inputKeys = ['account', 'name', 'email', 'password', 'passwordCheck']
+const inputConfig = {
+  account: {
+    label: '帳號',
+    inputType: 'text',
+    minlength: 1,
+    maxlength: 20,
+    required: true,
+    prefix: '@'
+  },
+  name: {
+    label: '名稱',
+    inputType: 'text',
+    maxlength: 50,
+    showLimit: true
+  },
+  email: {
+    label: 'Email',
+    inputType: 'email',
+    required: true
+  },
+  password: {
+    label: '密碼',
+    inputType: 'password',
+    minlength: 5,
+    maxlength: 20,
+    required: true
+  },
+  passwordCheck: {
+    label: '密碼確認',
+    inputType: 'password',
+    minlength: 5,
+    maxlength: 20,
+    required: true
+  }
+}
+
+// 再串接Vuex前，先用dummyUser頂著
+const dummyUser = {
+  id: 21,
+  account: 'cindy266',
+  name: '鰻魚燒',
+  cover: 'https://i.epochtimes.com/assets/uploads/2021/08/id13156667-shutterstock_376153318-450x322.jpg',
+  avatar: 'https://i.epochtimes.com/assets/uploads/2021/08/id13156667-shutterstock_376153318-450x322.jpg',
+  introduction: '我是絕對不可以吃的鰻魚燒，不可以吃我會遭天譴的',
+  email: 'aaa@bbb.ccc',
+  follower: 56,
+  following: 65
+}
+
+export default {
+  components: {
+    SiteNav,
+    GeneralInput
+  },
+  mixins: [inputValidationMethod],
+  data () {
+    return {
+      data: {
+        account: '',
+        name: '',
+        email: '',
+        password: '',
+        passwordCheck: ''
+      },
+      error: {
+        account: '',
+        name: '',
+        email: '',
+        password: '',
+        passwordCheck: ''
+      },
+      inputKeys,
+      config: inputConfig,
+      isLoading: true,
+      isProcessing: false
+    }
+  },
+  created () {
+    this.fetchUser(dummyUser.id)
+  },
+  methods: {
+    async fetchUser (userId) {
+      try {
+        this.isLoading = true
+        const response = await usersAPI.getUserData({ userId })
+
+        if (response.statusText !== 'OK') {
+          throw new Error(response.statusText)
+        }
+
+        this.data = {
+          ...this.data,
+          ...response.data
+        }
+
+        this.isLoading = false
+      } catch (error) {
+        Toast.fire({
+          icon: 'error',
+          title: '無法載入使用者資料，請稍後再試'
+        })
+      }
+    },
+    async handleSubmit (e) {
+      try {
+        let status
+        let message
+        let pass = true;
+
+        // 表單發送前的資料驗證
+        // 表單資料全部驗證完後，再決定是否送出表單，或者把所有的錯誤顯示出來
+        ({ status, message } = this.checkAccount(this.data.account))
+        if (status === false) {
+          this.error.account = message
+          pass = false
+        }
+
+        ({ status, message } = this.checkName(this.data.name))
+        if (status === false) {
+          this.error.name = message
+          pass = false
+        }
+
+        ({ status, message } = this.checkEmail(this.data.email))
+        if (status === false) {
+          this.error.email = message
+          pass = false
+        }
+
+        ({ status, message } = this.checkPassword(this.data.password))
+        if (status === false) {
+          this.error.password = message
+          pass = false
+        }
+
+        ({ status, message } = this.checkPassword(this.data.passwordCheck))
+        if (status === false) {
+          this.error.passwordCheck = message
+          pass = false
+        } else if (this.data.password !== this.data.passwordCheck) {
+          this.error.passwordCheck = '密碼不一致'
+          pass = false
+        }
+
+        if (pass === false) {
+          return
+        }
+
+        this.isProcessing = true
+
+        const form = e.target
+        const formData = new FormData(form)
+        const { data } = await usersAPI.updateUserSetting({ userId: dummyUser.id, formData })
+
+        if (data.status !== 'success') {
+          this.error.account = data.message
+          return
+        }
+
+        Toast.fire({
+          icon: 'success',
+          title: '成功修改使用者設定'
+        })
+
+        // 成功修改使用者設定後，清空密碼，避免使用者快速再送出重複的設定
+        this.data.password = ''
+        this.data.passwordCheck = ''
+      } catch (error) {
+        Toast.fire({
+          icon: 'error',
+          title: '無法修改使用者設定，請稍後再試'
+        })
+      } finally {
+        this.isProcessing = false
+      }
+    }
+  }
+}
+</script>
+
+<style lang="scss" scoped>
+.page-container {
+  color: #1C1C1C;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  font-family: 'Noto Sans TC', serif;
+  height: 100vh;
+  width: 100vw;
+}
+
+section.setting-container {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  flex-wrap: nowrap;
+
+  .page-header {
+    border-bottom: 1px solid #E6ECF0;
+    font-size: 19px;
+    font-weight: bold;
+    line-height: 28px;
+    padding-bottom: 14px;
+    padding-left: 20px;
+    padding-top: 13px;
+  }
+}
+
+form.setting-form {
+  display: flex;
+  flex-direction: column;
+  margin-left: 16px;
+  padding-top: 30px;
+  width: 642px;
+
+  .btn-submit {
+    align-self: flex-end;
+    border-radius: 50px;
+    font-size: 18px;
+    line-height: 26px;
+    margin-right: 6px;
+    margin-top: 20px;
+    padding: 10px 40px;
+  }
+}
+
+</style>

--- a/src/views/UserSetting.vue
+++ b/src/views/UserSetting.vue
@@ -196,6 +196,15 @@ export default {
         const { data } = await usersAPI.updateUserSetting({ userId: dummyUser.id, formData })
 
         if (data.status !== 'success') {
+          // 針對後端傳來的錯誤訊息，把帳號或信箱的重複提示，放到對應輸入框的錯誤提示訊息區域
+          if (/帳號/.test(data.message)) {
+            this.error.account = data.message
+            return
+          }
+          if (/信箱/.test(data.message)) {
+            this.error.email = data.message
+            return
+          }
           this.error.account = data.message
           return
         }


### PR DESCRIPTION
1. 建立網站通用按鈕顯示樣式btn-control和btn-control-outline（一堆`#FF6600`/`#FFFFFF`系列的按鈕可以套用這個樣式，統一預設、hover和disabled的行為）
2. 將新建立的按鈕樣式套用到FollowControlButton上（率先套用前述樣式）
3.  建立使用者設定頁並設定對應路由
4. 建立usersAPI中的`載入使用者資訊`和`更新使用者設定`
5. 建立`泛用型文字輸入框` （登入表單、註冊表單的輸入框應該都可以使用）
6. . 建立輸入內容驗證的共用方法（統一驗證邏輯，在使用時，component用mixins的方式導入，這樣在維護時可以減少問題）
7.  建立一個暫時的網站前台導覽列（基本上是空的，讓使用者設定頁表單區塊方便開發）
8. 增加「在使用者設定頁送出表單收到後端回傳的錯誤訊息後，把錯誤訊息放到對應輸入框錯誤訊息顯示區」的處理（對後端回傳的錯誤訊息用正規式進行檢驗）