### PR TITLE
修正錯誤 2022/03/01-1

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -44,10 +44,6 @@ export default {}
   &:hover {
     background-color: #b14700;
   }
-
-  &[disabled] {
-    opacity: 0.4;
-  }
 }
 .btn-control-outline {
   background-color: transparent;
@@ -57,6 +53,12 @@ export default {}
   &:hover {
     background-color: #FF6600;
     color: #FFFFFF
+  }
+}
+.btn-control,
+.btn-control-outline {
+  &[disabled] {
+    opacity: 0.4;
   }
 }
 

--- a/src/components/FollowControlButton.vue
+++ b/src/components/FollowControlButton.vue
@@ -40,17 +40,14 @@ export default {
     }
   },
   watch: {
-    initialUser (newValue) {
-      this.user = {
-        ...this.user,
-        ...newValue
-      }
-    }
-  },
-  created () {
-    this.user = {
-      ...this.user,
-      ...this.initialUser
+    initialUser: {
+      handler: function (newValue, oldValue) {
+        this.user = {
+          ...this.user,
+          ...newValue
+        }
+      },
+      immediate: true
     }
   },
   methods: {

--- a/src/components/HomeTweetArea.vue
+++ b/src/components/HomeTweetArea.vue
@@ -6,7 +6,7 @@
     <TweetBox @after-tweet="addTweetToList($event)" />
     <section class="tweet-list-container">
       <TweetList
-        :tweets="tweets"
+        :tweets="sortedTweets"
         :is-loading="isLoading"
       />
     </section>
@@ -159,13 +159,18 @@ export default {
       isLoading: true
     }
   },
+  computed: {
+    sortedTweets () {
+      return sortByTime(this.tweets, 'createdAt')
+    }
+  },
   created () {
     this.fetchTweets()
   },
   methods: {
     // 測試用
     // fetchTweets () {
-    //   this.tweets = sortByTime(dummyTweets, 'createdAt')
+    //   this.tweets = dummyTweets
     //   this.isLoading = false
     // }
     async fetchTweets () {
@@ -177,7 +182,7 @@ export default {
           throw new Error(response.statusText)
         }
 
-        this.tweets = sortByTime(response.data)
+        this.tweets = response.data
         this.isLoading = false
       } catch (error) {
         Toast.fire({

--- a/src/components/LikeTab.vue
+++ b/src/components/LikeTab.vue
@@ -6,15 +6,15 @@
       class="tweet-list"
     >
       <!-- 推文顯示清單 -->
-      <template v-show="tweets.length > 0">
+      <template v-show="sortedTweets.length > 0">
         <Tweet
-          v-for="tweet in tweets"
+          v-for="tweet in sortedTweets"
           :key="tweet.id"
           :initial-tweet="tweet"
         />
       </template>
       <h1
-        v-show="isLoading === false && tweets.length === 0"
+        v-show="isLoading === false && sortedTweets.length === 0"
         class="default-text"
       >
         尚無喜歡的內容
@@ -170,6 +170,11 @@ export default {
     this.fetchTweets(id)
     next()
   },
+  computed: {
+    sortedTweets () {
+      return sortByTime(this.tweets, 'createdAt')
+    }
+  },
   created () {
     const { id } = this.$route.params
     this.fetchTweets(id)
@@ -179,7 +184,7 @@ export default {
     /*
     fetchTweets (userId) {
       console.log(userId)
-      this.tweets = sortByTime(dummyTweets, 'createdAt')
+      this.tweets = dummyTweets
       this.isLoading = false
     }
     */
@@ -192,7 +197,12 @@ export default {
           throw new Error(response.statusText)
         }
 
-        this.tweets = sortByTime(response.data)
+        let tweets = response.data
+        tweets = tweets.map(tweet => ({
+          ...tweet,
+          id: tweet.TweetId
+        }))
+        this.tweets = tweets
         this.isLoading = false
       } catch (error) {
         Toast.fire({

--- a/src/components/LikeTab.vue
+++ b/src/components/LikeTab.vue
@@ -165,13 +165,10 @@ export default {
       isLoading: true
     }
   },
-  watch: {
-    '$store.state.currentUser': {
-      handler: function (newValue, oldValue) {
-        this.fetchTweets(newValue.id)
-      },
-      deep: true
-    }
+  beforeRouteUpdate (to, from, next) {
+    const { id } = to.params
+    this.fetchTweets(id)
+    next()
   },
   created () {
     const { id } = this.$route.params

--- a/src/components/RecommendedList.vue
+++ b/src/components/RecommendedList.vue
@@ -46,6 +46,7 @@ import { Toast } from '@/utils/helpers'
 import { emptyNameMethod } from '@/utils/mixins'
 import UserThumbnail from '@/components/UserThumbnail.vue'
 import FollowControlButton from '@/components/FollowControlButton.vue'
+import store from '@/store'
 
 // 測試資料，請保留以供測試
 
@@ -179,8 +180,11 @@ export default {
     // 確保先有使用者資訊，再取得推薦使用者清單
     '$store.state.currentUser': {
       handler: function (newValue, oldValue) {
-        this.userId = newValue.id
-        this.fetchUserList()
+        // 僅在有token的情況下操作
+        if (store.state.token !== '') {
+          this.userId = newValue.id
+          this.fetchUserList()
+        }
       },
       deep: true,
       immediate: true

--- a/src/components/ReplyTab.vue
+++ b/src/components/ReplyTab.vue
@@ -6,15 +6,15 @@
       class="reply-list"
     >
       <!-- 推文顯示清單 -->
-      <template v-show="replies.length > 0">
+      <template v-show="sortedReplies.length > 0">
         <Reply
-          v-for="reply in replies"
+          v-for="reply in sortedReplies"
           :key="reply.id"
           :initial-reply="reply"
         />
       </template>
       <h1
-        v-show="isLoading === false && replies.length === 0"
+        v-show="isLoading === false && sortedReplies.length === 0"
         class="default-text"
       >
         尚無推文與回覆
@@ -170,6 +170,11 @@ export default {
     this.fetchTweets(id)
     next()
   },
+  computed: {
+    sortedReplies () {
+      return sortByTime(this.replies, 'createdAt')
+    }
+  },
   created () {
     const { id } = this.$route.params
     this.fetchReplies(id)
@@ -179,7 +184,7 @@ export default {
     /*
     fetchReplies (userId) {
       console.log(userId)
-      this.replies = sortByTime(dummyReplies, 'createdAt')
+      this.replies = dummyReplies
       this.isLoading = false
     }
     */
@@ -192,7 +197,7 @@ export default {
           throw new Error(response.statusText)
         }
 
-        this.replies = sortByTime(response.data)
+        this.replies = response.data
         this.isLoading = false
       } catch (error) {
         Toast.fire({

--- a/src/components/ReplyTab.vue
+++ b/src/components/ReplyTab.vue
@@ -165,13 +165,10 @@ export default {
       isLoading: true
     }
   },
-  watch: {
-    '$store.state.currentUser': {
-      handler: function (newValue, oldValue) {
-        this.fetchReplies(newValue.id)
-      },
-      deep: true
-    }
+  beforeRouteUpdate (to, from, next) {
+    const { id } = to.params
+    this.fetchTweets(id)
+    next()
   },
   created () {
     const { id } = this.$route.params

--- a/src/components/TweetTab.vue
+++ b/src/components/TweetTab.vue
@@ -2,7 +2,7 @@
   <div class="tab-container">
     <!-- 推文列表 -->
     <TweetList
-      :tweets="tweets"
+      :tweets="sortedTweets"
       :is-loading="isLoading"
     />
   </div>
@@ -155,6 +155,11 @@ export default {
     this.fetchTweets(id)
     next()
   },
+  computed: {
+    sortedTweets () {
+      return sortByTime(this.tweets, 'createdAt')
+    }
+  },
   created () {
     const { id } = this.$route.params
     this.fetchTweets(id)
@@ -163,7 +168,7 @@ export default {
     // 測試用
     // fetchTweets (userId) {
     //   console.log(userId)
-    //   this.tweets = sortByTime(dummyTweets, 'createdAt')
+    //   this.tweets = dummyTweets
     //   this.isLoading = false
     // }
     async fetchTweets (userId) {
@@ -175,7 +180,7 @@ export default {
           throw new Error(response.statusText)
         }
 
-        this.tweets = sortByTime(response.data)
+        this.tweets = response.data
         this.isLoading = false
       } catch (error) {
         Toast.fire({

--- a/src/components/TweetTab.vue
+++ b/src/components/TweetTab.vue
@@ -155,14 +155,6 @@ export default {
     this.fetchTweets(id)
     next()
   },
-  watch: {
-    '$store.state.currentUser': {
-      handler: function (newValue, oldValue) {
-        this.fetchTweets(newValue.id)
-      },
-      deep: true
-    }
-  },
   created () {
     const { id } = this.$route.params
     this.fetchTweets(id)

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -106,7 +106,9 @@ const routes = [
     name: 'user-main',
     component: () => import('@/views/UserProfile'),
     beforeEnter: authorizeIsUser,
-    redirect: { name: 'user-tweets' },
+    redirect: to => {
+      return { name: 'user-tweets', params: { id: to.params.id } }
+    },
     children: [
       // 推文分頁
       {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -29,6 +29,6 @@ export const Toast = Swal.mixin({
 })
 
 // 依時間排序，時間近的在前面
-export const sortByTime = function (arr, key) {
+export const sortByTime = function (arr, key = 'createdAt') {
   return arr.sort((firstEl, secondEl) => moment(secondEl[key]).valueOf() - moment(firstEl[key]).valueOf())
 }

--- a/src/views/TweetAndReply.vue
+++ b/src/views/TweetAndReply.vue
@@ -74,7 +74,7 @@
         <section class="reply-section">
           <div class="reply-list">
             <Reply
-              v-for="reply in replies"
+              v-for="reply in sortedReplies"
               :key="reply.id"
               :initial-reply="reply"
             />
@@ -125,6 +125,11 @@ export default {
       isProcessing: false
     }
   },
+  computed: {
+    sortedReplies () {
+      return sortByTime(this.replies, 'createdAt')
+    }
+  },
   created () {
     const { id } = this.$route.params
     this.fetchTweet(id)
@@ -169,7 +174,7 @@ export default {
           throw new Error(response.statusText)
         }
 
-        this.replies = sortByTime(response.data, 'createdAt')
+        this.replies = response.data
 
         this.isLoadingTweet = false
       } catch (error) {


### PR DESCRIPTION
1. 修正跟隨按鈕內部狀態資訊未被正確設定的問題
2. 修正使用者Profile推文頁、推文與回覆頁、喜歡的內容頁，在分頁間與不同使用者間切換時，顯示內容未被正確刷新的問題
3. 移除登出時，依舊會抓取推薦使用者資訊的錯誤行為 https://github.com/yuanliif/AC-twitter/issues/30
4. 修正通用樣式btn-control-outline在disabled狀態下呈現
5. 修正資料進行時間排序時，因為未正確設定排序參考key值，導致排序結果錯誤的問題 https://github.com/yuanliif/AC-twitter/issues/31 https://github.com/yuanliif/AC-twitter/issues/34
6. 修正在個人頁面中的喜歡的內容，操作like失敗的問題 https://github.com/yuanliif/AC-twitter/issues/27
7. 將一些排序的資料放進computed，減少處理計算的負擔