### PR TITLE
修正錯誤 2022/03/01-2

### DIFF
--- a/src/components/CustomTextArea.vue
+++ b/src/components/CustomTextArea.vue
@@ -185,6 +185,7 @@ section.input-group {
     font-weight: 500;
     line-height: 29px;
     padding-left: 10px;
+    padding-top: 25px;
     position: relative;
     word-spacing: -0.25rem;
 
@@ -233,10 +234,10 @@ section.input-group {
     background-color: inherit;
     border: none;
     flex-grow: 1;
-    height: 148px;;
+    height: 125px;;
     padding-bottom: 4px;
     padding-left: 0px;
-    padding-top: 20px;
+    padding-top: 4px;
     resize: none;
   }
   textarea:focus {

--- a/src/components/LikeTab.vue
+++ b/src/components/LikeTab.vue
@@ -172,7 +172,7 @@ export default {
   },
   computed: {
     sortedTweets () {
-      return sortByTime(this.tweets, 'createdAt')
+      return sortByTime(this.tweets, 'relationshipCreatedAt')
     }
   },
   created () {

--- a/src/components/TweetBox.vue
+++ b/src/components/TweetBox.vue
@@ -18,6 +18,7 @@
         >{{ error }}</span>
         <button
           class="btn-control btn-tweet"
+          :disabled="isProcessing"
           @click.stop.prevent="tweet"
         >
           推文
@@ -67,14 +68,16 @@ export default {
           throw new Error(data.status)
         }
 
+        const { tweetData } = data
+
         this.$emit('after-tweet', {
-          id: new Date().valueOf(),
+          id: tweetData.id,
           userData: this.currentUser,
           description: this.description,
           replyAmount: 0,
           likeAmount: 0,
           userLiked: false,
-          createdAt: new Date()
+          createdAt: tweetData.createdAt
         })
 
         this.description = ''
@@ -90,7 +93,7 @@ export default {
     }
   }
 }
-</script>>
+</script>
 
 <style lang="scss" scoped>
 section.tweet-input-box {

--- a/src/utils/mixins.js
+++ b/src/utils/mixins.js
@@ -176,7 +176,11 @@ export const inputValidationMethod = {
 export const addPrefixFilter = {
   filters: {
     addPrefix (account) {
-      return `@${account}`
+      if (!account) {
+        return '原推文對象資訊缺少'
+      } else {
+        return `@${account}`
+      }
     }
   }
 }


### PR DESCRIPTION
1. 調整喜愛內容列表的顯示，使其正確顯示推文時間與正確的列表排序 (後端新版在travis上遇到問題，可能會再調整)
2. 修正新建的推文無法正確操作like/unlike的錯誤 https://github.com/yuanliif/AC-twitter/issues/29
3. 修正發推按鈕按下後，沒有出現disabled擋住使用者操作的錯誤
4. 調整UserProfileModal中自我介紹輸入框的顯示樣式 https://github.com/yuanliif/AC-twitter/issues/33
5. 增加帳號缺少情況下的處理 https://github.com/yuanliif/AC-twitter/issues/36 ，調整改顯示 `原推文對象資訊缺少`